### PR TITLE
guards against null returned from getClassModel()

### DIFF
--- a/src/main/java/cppclassanalyzer/data/typeinfo/GnuClassTypeInfoDB.java
+++ b/src/main/java/cppclassanalyzer/data/typeinfo/GnuClassTypeInfoDB.java
@@ -22,7 +22,7 @@ import ghidra.program.model.symbol.Namespace;
 
 import cppclassanalyzer.data.ClassTypeInfoManager;
 import cppclassanalyzer.data.manager.recordmanagers.ProgramRttiRecordManager;
-
+import ghidra.util.Msg;
 import ghidra.util.datastruct.LongArrayList;
 import ghidra.util.datastruct.LongIntHashtable;
 
@@ -283,6 +283,14 @@ public class GnuClassTypeInfoDB extends AbstractClassTypeInfoDB {
 				Arrays.stream(vmi.getBases())
 					.filter(Predicate.not(BaseClassTypeInfoModel::isVirtual))
 					.map(BaseClassTypeInfoModel::getClassModel)
+					.map((m) -> {
+						if (m == null) {
+							for (BaseClassTypeInfoModel base : vmi.getBases()) {
+								Msg.warn(getClass(), "possible null getClassModel() at 0x" + base.getAddress());
+							}
+						}
+						return m;
+					})
 					.filter(Objects::nonNull)
 					.map(manager::resolve)
 					.mapToLong(DatabaseObject::getKey)

--- a/src/main/java/cppclassanalyzer/data/typeinfo/GnuClassTypeInfoDB.java
+++ b/src/main/java/cppclassanalyzer/data/typeinfo/GnuClassTypeInfoDB.java
@@ -283,6 +283,7 @@ public class GnuClassTypeInfoDB extends AbstractClassTypeInfoDB {
 				Arrays.stream(vmi.getBases())
 					.filter(Predicate.not(BaseClassTypeInfoModel::isVirtual))
 					.map(BaseClassTypeInfoModel::getClassModel)
+					.filter(Objects::nonNull)
 					.map(manager::resolve)
 					.mapToLong(DatabaseObject::getKey)
 					.toArray();

--- a/src/main/java/ghidra/app/cmd/data/rtti/gcc/typeinfo/BaseClassTypeInfoModel.java
+++ b/src/main/java/ghidra/app/cmd/data/rtti/gcc/typeinfo/BaseClassTypeInfoModel.java
@@ -141,7 +141,7 @@ public final class BaseClassTypeInfoModel {
 	 * @see ClassTypeInfo#getName()
 	 */
 	public String getName() {
-		return getClassModel().getName();
+		return getClassModel().getName();	// FIXME: NPE
 	}
 
 	/**

--- a/src/main/java/ghidra/app/cmd/data/rtti/gcc/typeinfo/VmiClassTypeInfoModel.java
+++ b/src/main/java/ghidra/app/cmd/data/rtti/gcc/typeinfo/VmiClassTypeInfoModel.java
@@ -127,15 +127,12 @@ public final class VmiClassTypeInfoModel extends AbstractClassTypeInfoModel {
     private List<ClassTypeInfo> getParents() {
         List<ClassTypeInfo> parents = new ArrayList<>();
         for (BaseClassTypeInfoModel base : bases) {
-            if (!base.isVirtual()) {
-                parents.add(base.getClassModel());
+        	ClassTypeInfo parent = base.getClassModel();
+            if (parent != null && !base.isVirtual()) {
+                parents.add(parent);
             }
         }
-        try {
-            parents.addAll(getInheritableVirtualParents());
-        } catch (NullPointerException e) {
-            throw e;
-        }
+        parents.addAll(getInheritableVirtualParents());
         return parents;
     }
 
@@ -146,25 +143,19 @@ public final class VmiClassTypeInfoModel extends AbstractClassTypeInfoModel {
 
 	@Override
 	public Set<ClassTypeInfo> getVirtualParents() {
-		Set<ClassTypeInfo> result = new LinkedHashSet<>();
-		for (BaseClassTypeInfoModel base : bases) {
-			ClassTypeInfo parent = base.getClassModel();
-			if (base.isVirtual()) {
-				result.add(parent);
-			}
-			result.addAll(parent.getVirtualParents());
-		}
-		return result;
+		return getInheritableVirtualParents();
 	}
 
 	private Set<ClassTypeInfo> getInheritableVirtualParents() {
 		Set<ClassTypeInfo> result = new LinkedHashSet<>();
 		for (BaseClassTypeInfoModel base : bases) {
 			ClassTypeInfo parent = base.getClassModel();
-			if (base.isVirtual()) {
-				result.add(parent);
+			if (parent != null) {
+				if (base.isVirtual()) {
+					result.add(parent);
+				}
+				result.addAll(parent.getVirtualParents());
 			}
-			result.addAll(parent.getVirtualParents());
 		}
 		return result;
 	}

--- a/src/main/java/ghidra/app/cmd/data/rtti/gcc/typeinfo/VmiClassTypeInfoModel.java
+++ b/src/main/java/ghidra/app/cmd/data/rtti/gcc/typeinfo/VmiClassTypeInfoModel.java
@@ -128,7 +128,9 @@ public final class VmiClassTypeInfoModel extends AbstractClassTypeInfoModel {
         List<ClassTypeInfo> parents = new ArrayList<>();
         for (BaseClassTypeInfoModel base : bases) {
         	ClassTypeInfo parent = base.getClassModel();
-            if (parent != null && !base.isVirtual()) {
+        	if (parent == null) {
+        		Msg.warn(getClass(), "getParents(): null getClassModel() at 0x" + base.getAddress());
+        	} else if (parent != null && !base.isVirtual()) {
                 parents.add(parent);
             }
         }
@@ -155,6 +157,8 @@ public final class VmiClassTypeInfoModel extends AbstractClassTypeInfoModel {
 					result.add(parent);
 				}
 				result.addAll(parent.getVirtualParents());
+			} else {
+				Msg.warn(getClass(), "getInheritableVirtualParents(): null getClassModel() at 0x" + base.getAddress());
 			}
 		}
 		return result;


### PR DESCRIPTION
I got hit by NPEs when attempting right-click decompiled function argument > 'Auto Fill in Class Structure', I assume due to unknown parent hierarchies. Left 1 // FIXME as I honestly don't know what should be appropriate there.

Thanks & take care, sam_