### PR TITLE
Fix vftables being created with only 1 entry

### DIFF
--- a/src/main/java/cppclassanalyzer/vs/VsVtableModel.java
+++ b/src/main/java/cppclassanalyzer/vs/VsVtableModel.java
@@ -70,9 +70,9 @@ public class VsVtableModel implements Vtable {
 	}
 
 	private Function[] getFunctions(VfTableModel vftable) {
-		List<Function> functions = new ArrayList<>(vftable.getCount());
+		List<Function> functions = new ArrayList<>(vftable.getElementCount());
 		FunctionManager manager = program.getFunctionManager();
-		for (int i = 0; i < vftable.getCount(); i++) {
+		for (int i = 0; i < vftable.getElementCount(); i++) {
 			Function f = manager.getFunctionAt(vftable.getVirtualFunctionPointer(i));
 			if (f == null) {
 				break;


### PR DESCRIPTION
Since Ghidra 9.2.1 `getCount()` on `VfTableModel` no longer returns the number of functions, but the number of vftables. This change updates the code to use getElementCount() instead of getCount().
