### PR TITLE
Avoid NullPointerExceptions if plugin isn't activated yet

### DIFF
--- a/src/main/java/cppclassanalyzer/scanner/ItaniumAbiRttiScanner.java
+++ b/src/main/java/cppclassanalyzer/scanner/ItaniumAbiRttiScanner.java
@@ -154,6 +154,7 @@ public class ItaniumAbiRttiScanner implements RttiScanner {
 	@Override
 	public Set<Address> scanFundamentals(MessageLog log, TaskMonitor monitor)
 			throws CancelledException {
+		this.monitor = monitor;
 		relocations.addAll(getRelocations(CLASS_TYPESTRINGS));
 		if (!relocations.isEmpty()) {
 			relocatable = true;

--- a/src/main/java/cppclassanalyzer/utils/CppClassAnalyzerUtils.java
+++ b/src/main/java/cppclassanalyzer/utils/CppClassAnalyzerUtils.java
@@ -143,7 +143,7 @@ public final class CppClassAnalyzerUtils {
 		} else {
 			service = getService(program);
 		}
-		return service.getManager(program);
+		return service != null ? service.getManager(program) : null;
 	}
 
 	/**


### PR DESCRIPTION
If the plugin isn't activated yet, the analyzers will still try to check
if they can analyze the program. But if the plugin isn't activated the
service returned will be `null` and the crash will result in multiple
annoying popups.
This gracefully handles this, by propagating the null return value.