### PR TITLE
Don't catch no longer thrown DuplicateNameException

### DIFF
--- a/src/main/java/cppclassanalyzer/cmd/CreateExternalSymbolBackgroundCmd.java
+++ b/src/main/java/cppclassanalyzer/cmd/CreateExternalSymbolBackgroundCmd.java
@@ -64,7 +64,7 @@ public class CreateExternalSymbolBackgroundCmd extends BackgroundCommand {
 		}
 		try {
 			this.location = man.addExtLocation(lib, symbol, address, SourceType.IMPORTED, true);
-		} catch (InvalidInputException | DuplicateNameException e) {
+		} catch (InvalidInputException e) {
 			throw new AssertException(e);
 		}
 		return this.location != null;


### PR DESCRIPTION
DuplicateNameException isn't thrown at that call site as of 10.1