### PR TITLE
Use secondary vtables for filling class structures

### DIFF
--- a/src/main/java/cppclassanalyzer/vs/VsCppClassBuilder.java
+++ b/src/main/java/cppclassanalyzer/vs/VsCppClassBuilder.java
@@ -1,81 +1,68 @@
 package cppclassanalyzer.vs;
 
-import static ghidra.program.model.data.Undefined.isUndefined;
-
 import java.util.Map;
 
 import ghidra.app.cmd.data.rtti.*;
-import ghidra.app.cmd.data.rtti.gcc.ClassTypeInfoUtils;
+import ghidra.app.cmd.data.rtti.gcc.TypeInfoUtils;
+import ghidra.app.cmd.data.rtti.gcc.ClassTypeInfoUtils.Vptr;
 import ghidra.app.util.datatype.microsoft.MSDataTypeUtils;
+import ghidra.program.model.address.Address;
 import ghidra.program.model.data.DataType;
-import ghidra.program.model.data.DataTypeComponent;
-import ghidra.program.model.data.DataTypeManager;
-import ghidra.program.model.data.InvalidDataTypeException;
 import ghidra.program.model.data.Structure;
 import ghidra.program.model.listing.Program;
+import ghidra.program.model.mem.MemoryAccessException;
+import ghidra.program.model.mem.MemoryBufferImpl;
+import ghidra.util.Msg;
 
 public class VsCppClassBuilder extends AbstractCppClassBuilder {
 
-	private static final String VFPTR = "_vfptr";
-	private static final String VBPTR = "_vbptr";
+	private static final String VFPTR = "vfptr";
+	private static final String VBPTR = "vbptr";
+	private int currOffset = 0;
 
 	public VsCppClassBuilder(VsClassTypeInfo type) {
 		super(type);
 	}
 
-	@Override
-	protected AbstractCppClassBuilder getParentBuilder(ClassTypeInfo parent) {
-		return new VsCppClassBuilder((VsClassTypeInfo) parent);
-	}
-
-	@Override
-	protected void addVptr(Structure struct) {
-		try {
-			addPointers(struct);
-		} catch (InvalidDataTypeException e) {
-			return;
+	protected void addVptrs(Structure struct, int offset) {
+		currOffset = 0;
+		addVfptr(struct, offset);
+		if (!getType().getVirtualParents().isEmpty()) {
+			addVbptr(struct);
 		}
 	}
 
 	private void addVfptr(Structure struct, int offset) {
-		ClassTypeInfo type = getType();
-		Program program = getProgram();
-		DataType vfptr = ClassTypeInfoUtils.getVptrDataType(program, type);
-		DataTypeComponent comp = struct.getComponentContaining(offset);
-		if (comp == null || isUndefined(comp.getDataType())) {
-			replaceComponent(struct, vfptr, VFPTR, offset);
-		} else if (comp.getFieldName() == null || !comp.getFieldName().startsWith(SUPER)) {
-			replaceComponent(struct, vfptr, VFPTR, offset);
+		Vptr[] vptrs = getVptrs();
+		if (vptrs == null)
+			return;
+
+		for (int i = 0; i < vptrs.length; i++) {
+			Program program = getProgram();
+			Address vftableAddr = vptrs[i].getTableAddr();
+			Address objLocatorAddr = TypeInfoUtils.getAbsoluteAddress(program,
+					vftableAddr.subtract(pointerSize()));
+			try {
+				MemoryBufferImpl buf = new MemoryBufferImpl(program.getMemory(),
+						objLocatorAddr.add(pointerSize()));
+				int vftableOffset = buf.getInt(0);
+				if (offset == vftableOffset) {
+					replaceComponent(struct, vptrs[i].getDataType(), VFPTR, 0);
+					this.currOffset += pointerSize();
+					return;
+				}
+			} catch (MemoryAccessException e) {
+				Msg.error(this, e);
+			}
 		}
 	}
-
 
 	/**  {@link Rtti4Model#getVbTableOffset} */
-	private void addVbptr(Structure struct, int offset) throws InvalidDataTypeException {
+	private void addVbptr(Structure struct) {
 		Program program = getProgram();
-		DataTypeManager dtm = program.getDataTypeManager();
-		int ptrSize = program.getDefaultPointerSize();
-		DataType vbptr = dtm.getPointer(
-			MSDataTypeUtils.getPointerDisplacementDataType(program), ptrSize);
-		DataTypeComponent comp = struct.getComponentContaining(offset);
-		if (comp == null || isUndefined(comp.getDataType())) {
-			replaceComponent(struct, vbptr, VBPTR, offset);
-		} else if (comp.getFieldName() == null || !comp.getFieldName().startsWith(SUPER)) {
-			replaceComponent(struct, vbptr, VBPTR, offset);
-		}
-	}
-
-	private void addPointers(Structure struct) throws InvalidDataTypeException {
-		VsClassTypeInfo type = getType();
-		int offset = 0;
-		Vtable vtable = type.getVtable();
-		if (Vtable.isValid(vtable)) {
-			addVfptr(struct, offset);
-			offset = getProgram().getDefaultPointerSize();
-		}
-		if (!type.getVirtualParents().isEmpty()) {
-			addVbptr(struct, offset);
-		}
+		DataType vbptr = program.getDataTypeManager().getPointer(
+			MSDataTypeUtils.getPointerDisplacementDataType(program), pointerSize());
+		replaceComponent(struct, vbptr, VBPTR, currOffset);
 	}
 
 	@Override
@@ -86,5 +73,14 @@ public class VsCppClassBuilder extends AbstractCppClassBuilder {
 	@Override
 	protected VsClassTypeInfo getType() {
 		return (VsClassTypeInfo) super.getType();
+	}
+
+	@Override
+	protected boolean invalidFieldName(String name) {
+		if (name == null) {
+			return true;
+		}
+		return !name.startsWith(SUPER) && !name.contains(VFPTR) &&
+				!name.contains(VBPTR);
 	}
 }

--- a/src/main/java/ghidra/app/cmd/data/rtti/gcc/TypeInfoUtils.java
+++ b/src/main/java/ghidra/app/cmd/data/rtti/gcc/TypeInfoUtils.java
@@ -450,7 +450,7 @@ public class TypeInfoUtils {
 			.orElse("_ZTI" + type.getTypeName());
 	}
 
-	private static Address getAbsoluteAddress(Program program, Address address) {
+	public static Address getAbsoluteAddress(Program program, Address address) {
 		Memory mem = program.getMemory();
 		if (!mem.contains(address)) {
 			return null;

--- a/src/main/java/ghidra/app/cmd/data/rtti/gcc/VtableModel.java
+++ b/src/main/java/ghidra/app/cmd/data/rtti/gcc/VtableModel.java
@@ -173,7 +173,8 @@ public final class VtableModel implements GnuVtable {
 		Function[][] result = new Function[tableAddresses.length][];
 		for (int i = 0; i < tableAddresses.length; i++) {
 			result[i] = VtableUtils.getFunctionTable(program, tableAddresses[i]);
-		} return result;
+		}
+		return result;
 	}
 
 	@Override


### PR DESCRIPTION
This changes the way of embedding the base structures which are previously resolved, into the derived class by using its own secondary vtables for its bases instead. Notably, this fixes incorrect vptr definitions in a derived class structure in cases where primary vtables for its subobjects' classes do not exist.